### PR TITLE
[FEAT] 카테고리+가격범위 기반 검색 API 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,5 +72,6 @@ jobs:
               -e TNS_ADMIN=${{ secrets.TNS_ADMIN }} \
               -e BUCKET_NAME=${{ secrets.BUCKET_NAME }} \
               -e REPLICATE_SECRET=${{ secrets.REPLICATE_SECRET }} \
+              -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
               -v /home/ec2-user/wallet_zippick:/wallet_zippick:ro \
               ghcr.io/${{ github.repository }}/spring-backend:latest

--- a/zippick/src/main/java/zippick/domain/product/mapper/ProductMapper.java
+++ b/zippick/src/main/java/zippick/domain/product/mapper/ProductMapper.java
@@ -11,14 +11,19 @@ import java.util.List;
 @Mapper
 public interface ProductMapper {
 
-    List<ProductDto> findProductsByKeywordAndSort(
+    List<ProductDto> findProductsByKeywordAndCategoryAndSort(
             @Param("keyword") String keyword,
+            @Param("category") String category,
             @Param("sort") String sort,
             @Param("offset") Long offset,
             @Param("limit") Long limit
     );
 
-    long countProductsByKeyword(@Param("keyword") String keyword);
+    long countProductsByKeywordAndCategory(
+            @Param("keyword") String keyword,
+            @Param("category") String category
+    );
+
 
     List<ProductDto> findProductsBySize(
             @Param("category") String category,
@@ -40,4 +45,20 @@ public interface ProductMapper {
     ProductDetailResponse findProductDetailById(@Param("id") Long id);
 
     List<ProductLikedDto> findProductsByIds(@Param("ids") List<Long> ids);
+
+    List<ProductDto> findProductsByCategoryAndPrice(
+            @Param("category") String category,
+            @Param("minPrice") Long minPrice,
+            @Param("maxPrice") Long maxPrice,
+            @Param("sort") String sort,
+            @Param("offset") Long offset,
+            @Param("limit") Long limit
+    );
+
+    long countProductsByCategoryAndPrice(
+            @Param("category") String category,
+            @Param("minPrice") Long minPrice,
+            @Param("maxPrice") Long maxPrice
+    );
+
 }

--- a/zippick/src/main/java/zippick/domain/product/service/ProductService.java
+++ b/zippick/src/main/java/zippick/domain/product/service/ProductService.java
@@ -8,7 +8,7 @@ import zippick.domain.product.dto.response.ProductDetailResponse;
 import zippick.domain.product.dto.response.ProductResponse;
 
 public interface ProductService {
-    ProductResponse getProductsByKeyword(String keyword, String sort, Long offset);
+    ProductResponse getProductsByKeyword(String keyword, String category, String sort, Long offset);
 
     ProductResponse getProductsBySize(String category, Long width, Long depth, Long height, String sort, Long offset);
 
@@ -19,4 +19,7 @@ public interface ProductService {
     List<ProductLikedDto> getProductsByIds(List<Long> ids);
 
     InteriorAnalysisResponse analysisInteriorImage(MultipartFile roomImage);
+
+    ProductResponse getProductsByCategoryAndPrice(String category, Long minPrice, Long maxPrice, String sort, Long offset);
+
 }

--- a/zippick/src/main/java/zippick/domain/product/service/ProductServiceImpl.java
+++ b/zippick/src/main/java/zippick/domain/product/service/ProductServiceImpl.java
@@ -41,22 +41,21 @@ public class ProductServiceImpl implements ProductService {
     @Value("${openai.api-key}")
     private String openaiApiKey;
 
-
     @Override
     @Transactional(readOnly = true)
-    public ProductResponse getProductsByKeyword(String keyword, String sort, Long offset) {
+    public ProductResponse getProductsByKeyword(String keyword, String category, String sort, Long offset) {
         try {
-            long limit = 4; // 가져올 개수
+            long limit = 4;
 
-            List<ProductDto> products = productMapper.findProductsByKeywordAndSort(keyword, sort, offset, limit);
-            long totalCount = productMapper.countProductsByKeyword(keyword);
+            List<ProductDto> products = productMapper.findProductsByKeywordAndCategoryAndSort(keyword, category, sort, offset, limit);
+            long totalCount = productMapper.countProductsByKeywordAndCategory(keyword, category);
 
             return ProductResponse.builder()
                     .products(products)
                     .totalCount(totalCount)
                     .build();
         } catch (Exception e) {
-            throw new ZippickException(ErrorCode.INTERNAL_SERVER_ERROR, "키워드로 상품 검색 실패: "+e.getMessage());
+            throw new ZippickException(ErrorCode.INTERNAL_SERVER_ERROR, "키워드+카테고리로 상품 검색 실패: " + e.getMessage());
         }
     }
 
@@ -333,6 +332,29 @@ public class ProductServiceImpl implements ProductService {
                 .palette(palette)
                 .tags(tags)
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProductResponse getProductsByCategoryAndPrice(String category, Long minPrice, Long maxPrice, String sort, Long offset) {
+        try {
+            long limit = 4;
+
+            List<ProductDto> products = productMapper.findProductsByCategoryAndPrice(
+                    category, minPrice, maxPrice, sort, offset, limit
+            );
+
+            long totalCount = productMapper.countProductsByCategoryAndPrice(
+                    category, minPrice, maxPrice
+            );
+
+            return ProductResponse.builder()
+                    .products(products)
+                    .totalCount(totalCount)
+                    .build();
+        } catch (Exception e) {
+            throw new ZippickException(ErrorCode.INTERNAL_SERVER_ERROR, "카테고리+가격 조건 상품 검색 실패: " + e.getMessage());
+        }
     }
 
 }

--- a/zippick/src/main/resources/application.yml
+++ b/zippick/src/main/resources/application.yml
@@ -16,6 +16,9 @@ replicate:
   api:
     token: ${REPLICATE_SECRET}
 
+openai:
+  api-key: ${OPENAI_API_KEY}
+
 mybatis:
   mapper-locations: classpath*:mapper/**/*.xml
   configuration:

--- a/zippick/src/main/resources/mapper/product/ProductMapper.xml
+++ b/zippick/src/main/resources/mapper/product/ProductMapper.xml
@@ -5,7 +5,7 @@
 
 <mapper namespace="zippick.domain.product.mapper.ProductMapper">
 
-    <select id="findProductsByKeywordAndSort"
+    <select id="findProductsByKeywordAndCategoryAndSort"
             resultType="zippick.domain.product.dto.ProductDto">
         SELECT
         p.id AS id,
@@ -19,7 +19,10 @@
         FROM product p
         <where>
             <if test="keyword != null and keyword != ''">
-                p.name LIKE CONCAT(CONCAT('%', #{keyword}), '%')
+                AND p.name LIKE CONCAT(CONCAT('%', #{keyword}), '%')
+            </if>
+            <if test="category != null and category != ''">
+                AND p.category = #{category}
             </if>
         </where>
         <choose>
@@ -42,12 +45,15 @@
         OFFSET #{offset} ROWS FETCH NEXT #{limit} ROWS ONLY
     </select>
 
-    <select id="countProductsByKeyword" resultType="long">
+    <select id="countProductsByKeywordAndCategory" resultType="long">
         SELECT COUNT(*)
-        FROM product
+        FROM product p
         <where>
             <if test="keyword != null and keyword != ''">
-                name LIKE CONCAT(CONCAT('%', #{keyword}), '%')
+                AND p.name LIKE CONCAT(CONCAT('%', #{keyword}), '%')
+            </if>
+            <if test="category != null and category != ''">
+                AND p.category = #{category}
             </if>
         </where>
     </select>
@@ -142,5 +148,59 @@
             #{id}
         </foreach>
     </select>
+
+    <select id="findProductsByCategoryAndPrice" resultType="zippick.domain.product.dto.ProductDto">
+        SELECT
+        p.id AS id,
+        p.name AS name,
+        p.price AS price,
+        p.thumbnail_image_url AS imageUrl,
+        p.created_at AS createdAt,
+        (
+        SELECT COUNT(*) FROM orders o WHERE o.product_id = p.id
+        ) AS orderCount
+        FROM product p
+        WHERE 1=1
+        <if test="category != null and category != ''">
+            AND p.category = #{category}
+        </if>
+        <if test="minPrice != null">
+            AND p.price &gt;= #{minPrice}
+        </if>
+        <if test="maxPrice != null">
+            AND p.price &lt;= #{maxPrice}
+        </if>
+        <choose>
+            <when test="sort == 'price_asc'">
+                ORDER BY p.price ASC
+            </when>
+            <when test="sort == 'price_desc'">
+                ORDER BY p.price DESC
+            </when>
+            <when test="sort == 'popular'">
+                ORDER BY orderCount DESC
+            </when>
+            <otherwise>
+                ORDER BY p.created_at DESC
+            </otherwise>
+        </choose>
+        OFFSET #{offset} ROWS FETCH NEXT #{limit} ROWS ONLY
+    </select>
+
+    <select id="countProductsByCategoryAndPrice" resultType="long">
+        SELECT COUNT(*)
+        FROM product p
+        WHERE 1=1
+        <if test="category != null and category != ''">
+            AND p.category = #{category}
+        </if>
+        <if test="minPrice != null">
+            AND p.price &gt;= #{minPrice}
+        </if>
+        <if test="maxPrice != null">
+            AND p.price &lt;= #{maxPrice}
+        </if>
+    </select>
+
 
 </mapper>


### PR DESCRIPTION
## #️⃣ Issue Number
#43 

## 📝 요약(Summary)
- 카테고리, 가격범위, 정렬조건으로 상품 목록 검색하는 API 구현
- 키워드 기반 검색시 카테고리도 받을수있게 수정
- 오픈ai 시크릿키 추가에 따른 CICD Workflow 수정

## 📸스크린샷 (선택)
테스트완료
<img width="1398" height="733" alt="image" src="https://github.com/user-attachments/assets/7b0e2d51-152c-4b8c-8428-4cdfb90132ac" />

## 💬 공유사항 to 리뷰어
application.yml 에 open ai 키를 시크릿으로 추가했습니다 (기존 소문자에서 대문자로 변경함)