### PR TITLE
[FEAT] 푸시 알림 기능 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ jobs:
               -e BUCKET_NAME=${{ secrets.BUCKET_NAME }} \
               -e REPLICATE_SECRET=${{ secrets.REPLICATE_SECRET }} \
               -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
+              -e FIREBASE_CREDENTIAL_JSON="${{ secrets.FIREBASE_CREDENTIAL_JSON }}" \
               -v /home/ec2-user/wallet_zippick:/wallet_zippick:ro \
               -v /home/ec2-user/.aws:/root/.aws:ro \
               ghcr.io/${{ github.repository }}/spring-backend:latest

--- a/zippick/build.gradle
+++ b/zippick/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
 	//auth
 	implementation 'org.springframework.security:spring-security-crypto'
+
+	// Firebase
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 

--- a/zippick/src/main/java/zippick/domain/notification/controller/FcmController.java
+++ b/zippick/src/main/java/zippick/domain/notification/controller/FcmController.java
@@ -1,0 +1,32 @@
+package zippick.domain.notification.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zippick.domain.notification.dto.request.FcmTokenRequest;
+import zippick.domain.notification.dto.response.FcmTokenResponse;
+import zippick.domain.notification.service.FcmService;
+
+@RestController
+@RequestMapping("/api/fcm")
+@RequiredArgsConstructor
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @PostMapping("/register")
+    public ResponseEntity<FcmTokenResponse> registerFcm(HttpServletRequest request,
+            @RequestBody FcmTokenRequest registerRequest) {
+        Long memberId = (Long) request.getAttribute("memberId");
+
+        if (memberId == null) {
+            throw new IllegalStateException("memberId 누락: 필터에서 등록되지 않았습니다.");
+        }
+
+        fcmService.registerToken(memberId, registerRequest);
+
+        return ResponseEntity.ok(new FcmTokenResponse(true));
+    }
+}
+

--- a/zippick/src/main/java/zippick/domain/notification/controller/NotificationController.java
+++ b/zippick/src/main/java/zippick/domain/notification/controller/NotificationController.java
@@ -1,0 +1,46 @@
+package zippick.domain.notification.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zippick.domain.notification.dto.request.NotificationRequest;
+import zippick.domain.notification.dto.response.ReadNotificationResponse;
+import zippick.domain.notification.dto.response.SendNotificationResponse;
+import zippick.domain.notification.service.NotificationService;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping("/send")
+    public ResponseEntity<SendNotificationResponse> sendNotification(
+            HttpServletRequest request,
+            @RequestBody NotificationRequest reqBody) {
+
+        Long memberId = (Long) request.getAttribute("memberId");
+        if (memberId == null) {
+            throw new IllegalStateException("memberId가 누락되었습니다.");
+        }
+
+        SendNotificationResponse response = notificationService.sendNotification(memberId, reqBody);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ReadNotificationResponse> getNotifications(
+            HttpServletRequest request,
+            @RequestParam int offset) {
+
+        Long memberId = (Long) request.getAttribute("memberId");
+        if (memberId == null) {
+            throw new IllegalStateException("memberId가 누락되었습니다.");
+        }
+
+        ReadNotificationResponse response = notificationService.getNotifications(memberId, offset);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/zippick/src/main/java/zippick/domain/notification/dto/FcmTokenDto.java
+++ b/zippick/src/main/java/zippick/domain/notification/dto/FcmTokenDto.java
@@ -1,0 +1,16 @@
+package zippick.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FcmTokenDto {
+    private Long id;
+    private Long memberId;
+    private String fcmToken;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/zippick/src/main/java/zippick/domain/notification/dto/NotificationDto.java
+++ b/zippick/src/main/java/zippick/domain/notification/dto/NotificationDto.java
@@ -1,0 +1,23 @@
+package zippick.domain.notification.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationDto {
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+
+    // 저장용
+    private Long createdBy;
+    private Long memberId;
+}

--- a/zippick/src/main/java/zippick/domain/notification/dto/request/FcmTokenRequest.java
+++ b/zippick/src/main/java/zippick/domain/notification/dto/request/FcmTokenRequest.java
@@ -1,0 +1,8 @@
+package zippick.domain.notification.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class FcmTokenRequest {
+    private String fcmToken;
+}

--- a/zippick/src/main/java/zippick/domain/notification/dto/request/NotificationRequest.java
+++ b/zippick/src/main/java/zippick/domain/notification/dto/request/NotificationRequest.java
@@ -1,0 +1,13 @@
+package zippick.domain.notification.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class NotificationRequest {
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/zippick/src/main/java/zippick/domain/notification/dto/response/FcmTokenResponse.java
+++ b/zippick/src/main/java/zippick/domain/notification/dto/response/FcmTokenResponse.java
@@ -1,0 +1,11 @@
+package zippick.domain.notification.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FcmTokenResponse {
+    private boolean success;
+}
+

--- a/zippick/src/main/java/zippick/domain/notification/dto/response/ReadNotificationResponse.java
+++ b/zippick/src/main/java/zippick/domain/notification/dto/response/ReadNotificationResponse.java
@@ -1,0 +1,13 @@
+package zippick.domain.notification.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import zippick.domain.notification.dto.NotificationDto;
+
+@Getter
+@AllArgsConstructor
+public class ReadNotificationResponse {
+    private List<NotificationDto> notifications;
+}

--- a/zippick/src/main/java/zippick/domain/notification/dto/response/SendNotificationResponse.java
+++ b/zippick/src/main/java/zippick/domain/notification/dto/response/SendNotificationResponse.java
@@ -1,0 +1,11 @@
+package zippick.domain.notification.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SendNotificationResponse {
+    private boolean success;
+    private Long notificationId;
+}

--- a/zippick/src/main/java/zippick/domain/notification/mapper/FcmTokenMapper.java
+++ b/zippick/src/main/java/zippick/domain/notification/mapper/FcmTokenMapper.java
@@ -1,0 +1,14 @@
+package zippick.domain.notification.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import zippick.domain.notification.dto.FcmTokenDto;
+
+@Mapper
+public interface FcmTokenMapper {
+    void insertFcmToken(@Param("fcmToken") FcmTokenDto token);
+
+    void updateFcmToken(@Param("memberId") Long memberId, @Param("fcmToken") String fcmToken);
+
+    FcmTokenDto findByMemberId(@Param("memberId") Long memberId);
+}

--- a/zippick/src/main/java/zippick/domain/notification/mapper/NotificationMapper.java
+++ b/zippick/src/main/java/zippick/domain/notification/mapper/NotificationMapper.java
@@ -1,0 +1,15 @@
+package zippick.domain.notification.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import zippick.domain.notification.dto.NotificationDto;
+
+@Mapper
+public interface NotificationMapper {
+    void insertNotification(NotificationDto notification);
+
+    List<NotificationDto> findNotificationsByMemberId(@Param("memberId") Long memberId,
+            @Param("offset") int offset);
+
+}

--- a/zippick/src/main/java/zippick/domain/notification/service/FcmService.java
+++ b/zippick/src/main/java/zippick/domain/notification/service/FcmService.java
@@ -1,0 +1,7 @@
+package zippick.domain.notification.service;
+
+import zippick.domain.notification.dto.request.FcmTokenRequest;
+
+public interface FcmService {
+    void registerToken(Long memberId, FcmTokenRequest request);
+}

--- a/zippick/src/main/java/zippick/domain/notification/service/FcmServiceImpl.java
+++ b/zippick/src/main/java/zippick/domain/notification/service/FcmServiceImpl.java
@@ -1,0 +1,32 @@
+package zippick.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import zippick.domain.notification.dto.request.FcmTokenRequest;
+import zippick.domain.notification.mapper.FcmTokenMapper;
+import zippick.domain.notification.dto.FcmTokenDto;
+
+@Service
+@RequiredArgsConstructor
+public class FcmServiceImpl implements FcmService {
+
+    private final FcmTokenMapper fcmTokenMapper;
+
+    @Override
+    @Transactional
+    public void registerToken(Long memberId, FcmTokenRequest request) {
+
+        FcmTokenDto existing = fcmTokenMapper.findByMemberId(memberId);
+        if (existing == null) {
+            FcmTokenDto token = FcmTokenDto.builder()
+                    .memberId(memberId)
+                    .fcmToken(request.getFcmToken())
+                    .build();
+            fcmTokenMapper.insertFcmToken(token);
+        } else {
+            fcmTokenMapper.updateFcmToken(memberId, request.getFcmToken());
+        }
+    }
+}
+

--- a/zippick/src/main/java/zippick/domain/notification/service/NotificationService.java
+++ b/zippick/src/main/java/zippick/domain/notification/service/NotificationService.java
@@ -1,0 +1,13 @@
+package zippick.domain.notification.service;
+
+import zippick.domain.notification.dto.request.NotificationRequest;
+import zippick.domain.notification.dto.response.ReadNotificationResponse;
+import zippick.domain.notification.dto.response.SendNotificationResponse;
+
+public interface NotificationService {
+    SendNotificationResponse sendNotification(Long memberId, NotificationRequest request);
+
+    ReadNotificationResponse getNotifications(Long memberId, int offset);
+
+}
+

--- a/zippick/src/main/java/zippick/domain/notification/service/NotificationServiceImpl.java
+++ b/zippick/src/main/java/zippick/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,51 @@
+package zippick.domain.notification.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import zippick.domain.notification.dto.NotificationDto;
+import zippick.domain.notification.dto.request.NotificationRequest;
+import zippick.domain.notification.dto.response.ReadNotificationResponse;
+import zippick.domain.notification.dto.response.SendNotificationResponse;
+import zippick.domain.notification.mapper.FcmTokenMapper;
+import zippick.domain.notification.mapper.NotificationMapper;
+import zippick.infra.fcm.FcmUtil;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationMapper notificationMapper;
+    private final FcmTokenMapper fcmTokenMapper;
+    private final FcmUtil fcmUtil;
+
+    @Override
+    @Transactional
+    public SendNotificationResponse sendNotification(Long memberId, NotificationRequest request) {
+
+        NotificationDto notification = NotificationDto.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .createdAt(request.getCreatedAt())
+                .createdBy(memberId)
+                .memberId(memberId)
+                .build();
+
+        notificationMapper.insertNotification(notification);
+
+        String fcmToken = fcmTokenMapper.findByMemberId(memberId).getFcmToken();
+        fcmUtil.sendMessageTo(fcmToken, request.getTitle(), request.getContent());
+
+        return new SendNotificationResponse(true, notification.getId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReadNotificationResponse getNotifications(Long memberId, int offset) {
+        List<NotificationDto> list = notificationMapper.findNotificationsByMemberId(memberId, offset);
+        return new ReadNotificationResponse(list);
+    }
+
+
+}

--- a/zippick/src/main/java/zippick/global/config/FirebaseConfig.java
+++ b/zippick/src/main/java/zippick/global/config/FirebaseConfig.java
@@ -1,0 +1,37 @@
+package zippick.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${FIREBASE_CREDENTIAL_JSON}")
+    private String firebaseCredentialJson;
+
+    @PostConstruct
+    public void initFirebase() {
+        try {
+            if (FirebaseApp.getApps().isEmpty()) {
+                InputStream serviceAccount =
+                        new ByteArrayInputStream(firebaseCredentialJson.getBytes(StandardCharsets.UTF_8));
+
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                        .build();
+
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Firebase 초기화 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/zippick/src/main/java/zippick/global/config/S3Config.java
+++ b/zippick/src/main/java/zippick/global/config/S3Config.java
@@ -18,13 +18,15 @@ public class S3Config {
   }
 
   // 로컬
-/*  @Bean
+/*
+  @Bean
   public S3Client s3Client() {
     return S3Client.builder()
             .region(Region.AP_NORTHEAST_2)
             .credentialsProvider(ProfileCredentialsProvider.create("zippick"))
             .build();
-  }*/
+  }
+*/
 
 }
 

--- a/zippick/src/main/java/zippick/global/exception/ErrorCode.java
+++ b/zippick/src/main/java/zippick/global/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     EMAIL_SEND_FAIL("5001", "이메일 전송 실패", HttpStatus.INTERNAL_SERVER_ERROR),
     FILE_UPLOAD_FAIL("5002", "파일 업로드 실패", HttpStatus.INTERNAL_SERVER_ERROR),
     NO_ORDER_HISTORY("5003", "주문 내역 없음", HttpStatus.NOT_FOUND),
-    LIKED_NOT_FOUND("5004", "찜 조회 실패", HttpStatus.NOT_FOUND);
+    LIKED_NOT_FOUND("5004", "찜 조회 실패", HttpStatus.NOT_FOUND),
+    FCM_SEND_FAIL("5005", "알림 전송 실패", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/zippick/src/main/java/zippick/infra/fcm/FcmUtil.java
+++ b/zippick/src/main/java/zippick/infra/fcm/FcmUtil.java
@@ -1,0 +1,27 @@
+package zippick.infra.fcm;
+
+import com.google.firebase.messaging.*;
+import org.springframework.stereotype.Component;
+import zippick.global.exception.ErrorCode;
+import zippick.global.exception.ZippickException;
+
+@Component
+public class FcmUtil {
+
+    public void sendMessageTo(String targetToken, String title, String body) {
+        Message message = Message.builder()
+                .setToken(targetToken)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            throw new ZippickException(ErrorCode.FCM_SEND_FAIL, "FCM 전송 실패: " + e.getMessage());
+        }
+    }
+}
+

--- a/zippick/src/main/resources/application.yml
+++ b/zippick/src/main/resources/application.yml
@@ -53,3 +53,6 @@ logging:
     org.springframework: INFO
     zippick.domain.product.mapper: DEBUG
     org.mybatis: DEBUG
+
+firebase:
+  credentials: ${FIREBASE_CREDENTIAL_JSON}

--- a/zippick/src/main/resources/mapper/notification/FcmTokenMapper.xml
+++ b/zippick/src/main/resources/mapper/notification/FcmTokenMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="zippick.domain.notification.mapper.FcmTokenMapper">
+
+    <insert id="insertFcmToken">
+        INSERT INTO fcm_token (
+            id, member_id, fcm_token, created_at
+        ) VALUES (
+                     seq_fcm_token.NEXTVAL,
+                     #{fcmToken.memberId},
+                     #{fcmToken.fcmToken},
+                     SYSTIMESTAMP
+                 )
+    </insert>
+
+    <update id="updateFcmToken">
+        UPDATE fcm_token
+        SET fcm_token = #{fcmToken},
+            updated_at = SYSTIMESTAMP
+        WHERE member_id = #{memberId}
+    </update>
+
+    <select id="findByMemberId" resultType="zippick.domain.notification.dto.FcmTokenDto">
+        SELECT * FROM fcm_token WHERE member_id = #{memberId}
+    </select>
+</mapper>

--- a/zippick/src/main/resources/mapper/notification/NotificationMapper.xml
+++ b/zippick/src/main/resources/mapper/notification/NotificationMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="zippick.domain.notification.mapper.NotificationMapper">
+
+    <insert id="insertNotification" parameterType="zippick.domain.notification.dto.NotificationDto">
+        <selectKey keyProperty="id" resultType="long" order="BEFORE">
+            SELECT SEQ_NOTIFICATION.NEXTVAL FROM DUAL
+        </selectKey>
+        INSERT INTO notification (
+        id, title, content, created_at, created_by, member_id
+        ) VALUES (
+        #{id}, #{title}, #{content}, #{createdAt}, #{createdBy}, #{memberId}
+        )
+    </insert>
+
+    <select id="findNotificationsByMemberId" resultType="zippick.domain.notification.dto.NotificationDto">
+        SELECT
+        id,
+        title,
+        content,
+        created_at AS createdAt,
+        created_by AS createdBy,
+        member_id AS memberId
+        FROM notification
+        WHERE member_id = #{memberId}
+        ORDER BY created_at DESC
+        OFFSET #{offset} ROWS FETCH NEXT 8 ROWS ONLY
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣ Issue Number
#55 

## 📝 요약(Summary)
- FCM을 통한 알림 기능 추가
- Push 알림 연동 (상단팝업으로 날라옵니다. 에뮬레이터 기준 api실행후 뜨는데까지 약 4초걸림)
- 알림은 DB - Notification 테이블에 저장됩니다.

## 📸스크린샷 (선택)
<img width="1361" height="667" alt="알림스웨거" src="https://github.com/user-attachments/assets/6d153e9c-9692-43ef-b2c1-ae215729f457" />
<img width="1345" height="200" alt="알림스웨거2" src="https://github.com/user-attachments/assets/e3a1ea61-288c-4aa1-b671-8b3ced0b2cba" />
<img width="1388" height="527" alt="알림조회1" src="https://github.com/user-attachments/assets/d9c93cea-f348-4d74-b884-10a09ee15178" />
<img width="1357" height="496" alt="알림조회2" src="https://github.com/user-attachments/assets/e49225f1-a848-4cbd-9106-32e2ae1f321a" />
<img width="270" height="600" alt="알림1" src="https://github.com/user-attachments/assets/2fe2293d-dd54-48bc-b7a1-06646334e0c2" />
<img width="270" height="600" alt="알림2" src="https://github.com/user-attachments/assets/f8d8f6b6-d29b-4d83-ba25-fd2914bf0cda" />

## 💬 공유사항 to 리뷰어
- yml에 시크릿값 하나 추가됬습니다. 노션 > application.yml 참고해주세요